### PR TITLE
feat: update goruntime version to 1.16

### DIFF
--- a/gcp-data-drive/Dockerfile
+++ b/gcp-data-drive/Dockerfile
@@ -16,7 +16,7 @@
 # This is based on Debian and sets the GOPATH to /go.
 # https://hub.docker.com/_/golang
 
-FROM golang:1.13 as builder
+FROM golang:1.16 as builder
 
 # Create and change to the app directory.
 WORKDIR /app

--- a/gcp-data-drive/cmd/webserver/app.yaml
+++ b/gcp-data-drive/cmd/webserver/app.yaml
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-runtime: go113
+runtime: go116
 
 handlers:
 - url: /.*

--- a/gcp-data-drive/go.mod
+++ b/gcp-data-drive/go.mod
@@ -13,7 +13,7 @@
 // limitations under the License.
 module github.com/GoogleCloudPlatform/DIY-Tools/gcp-data-drive/gcpdatadrive
 
-go 1.13
+go 1.16
 
 require (
 	cloud.google.com/go/bigquery v1.0.1


### PR DESCRIPTION
    - update to latest Go version supported by current GCP
    - go1.13 end of support in 2020.08